### PR TITLE
GH-49: Updated to use kettle 2.1.0 (resolves #49).

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
         "cookie-parser": "1.4.5",
         "express": "4.17.1",
         "express-session": "1.17.1",
-        "infusion": "3.0.0-dev.20201113T153152Z.32176dcbe.FLUID-6145",
+        "infusion": "3.0.0-dev.20210120T204128Z.6e4be079f.FLUID-6580",
         "serve-index": "1.9.1"
     },
     "devDependencies": {
         "eslint": "7.17.0",
         "eslint-config-fluid": "2.0.0",
         "fluid-lint-all": "1.0.0",
-        "kettle": "1.16.0",
+        "kettle": "2.1.0",
         "nyc": "12.0.2",
         "node-jqunit": "1.1.8"
     }

--- a/tests/js/lib/request.js
+++ b/tests/js/lib/request.js
@@ -6,7 +6,7 @@ kettle.loadTestingSupport();
 
 fluid.defaults("fluid.test.express.request", {
     gradeNames: ["kettle.test.request.httpCookie"],
-    path: {
+    url: {
         expander: {
             funcName: "fluid.stringTemplate",
             args:     ["%baseUrl%endpoint", { baseUrl: "{testEnvironment}.options.baseUrl", endpoint: "{that}.options.endpoint"}]

--- a/tests/js/method/method-caseholder.js
+++ b/tests/js/method/method-caseholder.js
@@ -28,7 +28,7 @@ fluid.tests.express.method.caseHolder.checkMethodAndCounts = function (body, met
 
 fluid.defaults("fluid.tests.express.method.request", {
     gradeNames: ["kettle.test.request.http"],
-    path:       "{testEnvironment}.options.baseUrl",
+    url:        "{testEnvironment}.options.baseUrl",
     port:       "{testEnvironment}.options.port"
 });
 

--- a/tests/js/middleware/middleware-caseholder.js
+++ b/tests/js/middleware/middleware-caseholder.js
@@ -192,7 +192,7 @@ fluid.defaults("fluid.tests.express.middleware.caseHolder", {
         counterRequest: {
             type: "kettle.test.request.http",
             options: {
-                path: "{testEnvironment}.options.baseUrl",
+                url: "{testEnvironment}.options.baseUrl",
                 port: "{testEnvironment}.options.port",
                 method: "GET"
             }
@@ -200,7 +200,7 @@ fluid.defaults("fluid.tests.express.middleware.caseHolder", {
         counterSecondRequest: {
             type: "kettle.test.request.http",
             options: {
-                path: "{testEnvironment}.options.baseUrl",
+                url: "{testEnvironment}.options.baseUrl",
                 port: "{testEnvironment}.options.port",
                 method: "GET"
             }

--- a/tests/js/querystring/querystring-express-tests.js
+++ b/tests/js/querystring/querystring-express-tests.js
@@ -18,7 +18,7 @@ fluid.registerNamespace("fluid.tests.express.querystring.withJsonQueryParser.cas
 
 fluid.defaults("fluid.tests.express.querystring.withJsonQueryParser.request", {
     gradeNames: ["kettle.test.request.http"],
-    path: {
+    url: {
         expander: {
             funcName: "fluid.stringTemplate",
             args: [


### PR DESCRIPTION
See #49  for details.